### PR TITLE
Corrected shape of resnet to pull from shape_final instead of padding

### DIFF
--- a/calodiffusion/models/layerdiffusion.py
+++ b/calodiffusion/models/layerdiffusion.py
@@ -25,7 +25,7 @@ class LayerDiffusion(CaloDiffusion):
 
     def init_model(self):
         cond_size = 3 if self.hgcal else 1
-        self.layer_model = ResNet(dim_in = self.config['SHAPE_PAD'][2] + 1, num_layers = 5, cond_size = cond_size).to(device = self.device)
+        self.layer_model = ResNet(dim_in = self.config['SHAPE_FINAL'][2] + 1, num_layers = 5, cond_size = cond_size).to(device = self.device)
         model = super().init_model().to(device = self.device)
         self.base_model = model
         return model


### PR DESCRIPTION
Pion layer models were failing because in pion config 'SHAPE_PAD' is the same as "SHAPE_ORIG" and not "SHAPE_FINAL" - sidesteps this issue by changing resnet init. 

Adds a training int test for pion layer models